### PR TITLE
Change yarn publish registry to npm

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,1 +1,3 @@
+npmRegistryServer: "https://registry.npmjs.org"
+
 yarnPath: .yarn/releases/yarn-4.13.0.cjs


### PR DESCRIPTION
## Summary
- Set `npmRegistryServer` to `https://registry.npmjs.org` in `.yarnrc.yml` so that `yarn publish` targets the public npm registry

## Test plan
- [ ] Verify `.yarnrc.yml` contains the correct registry URL
- [ ] Run `yarn config get npmRegistryServer` to confirm it resolves to `https://registry.npmjs.org`

https://claude.ai/code/session_014wQfenVfGXCx3FfhXLK2RL